### PR TITLE
Added difficulty settings.

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,22 @@
                     </div>
                 </div>
                 <div id="specialMessageModal" class="specialMessageModal hide">
-                    <div class="modal">
+                    <form class="modal" id="specialMessageForm">
                         <h2 id="specialMessageHeader"></h2>
                         <div id="specialMessageContent">
                         </div>
-                        <button id="specialMessageButton"></button>
-                    </div>
+                        <fieldset id="specialMessageFieldset" class="hide">
+                            <input id="0" type="radio" name="difficulty" value="0">
+                            <label for="0">Accessible</label>
+                            <input id="1" type="radio" name="difficulty" value="1" checked>
+                            <label for="1">Suggested</label>
+                            <input id="2" type="radio" name="difficulty" value="2">
+                            <label for="2">Classic</label>
+                            <input id="3" type="radio" name="difficulty" value="3">
+                            <label for="3">Nightmare</label>
+                        </fieldset>
+                        <button id="specialMessageButton" type="submit"></button>
+                    </form>
                 </div>
                 <div id="inventory" class="inventory hide">
                     <div class="modal">

--- a/src/classes/Critter.ts
+++ b/src/classes/Critter.ts
@@ -4,9 +4,10 @@ import Player from "./Player"
 import Game from "./Game"
 import MapHandler from "./MapHandler"
 import { critterTypes, CritterAction, objectFactory, itemFactory } from "../util/entityTypes"
-import { randomElement } from "../util/randomness";
+import { randomElement } from "../util/randomness"
 import Logger from "./Logger"
-import SoundHandler from "./SoundHandler";
+import SoundHandler from "./SoundHandler"
+import { monsterStrengthScale } from "../util/difficultySettings"
 
 interface CritterParams {
     critterType: keyof typeof critterTypes;
@@ -47,11 +48,12 @@ class Critter extends Entity {
     idleSound:string;
     constructor({critterType, x, y, z, ...rest}:CritterParams) {
         const critterDetails = critterTypes[critterType];
+        const difficultyScale = monsterStrengthScale(Game.getInstance().difficulty);
         super({
             sprite: Sprite.from(critterDetails.spriteName),
-            hp: critterDetails.hp,
-            actPeriod: critterDetails.actPeriod,
-            movePeriod: critterDetails.movePeriod,
+            hp: critterDetails.hp * difficultyScale.health,
+            actPeriod: critterDetails.actPeriod / difficultyScale.speed,
+            movePeriod: critterDetails.movePeriod / difficultyScale.speed,
             acts: true,
             x: x,
             y: y,
@@ -66,7 +68,7 @@ class Critter extends Entity {
         this.persistence = critterDetails.persistence ? critterDetails.persistence : 10;
         this.actionTypes = critterDetails.actionTypes ? critterDetails.actionTypes : ["violence"];
         this.entityFlags = critterDetails.entityFlags ? critterDetails.entityFlags : [];
-        this.strength = critterDetails.strength ? critterDetails.strength : 1;
+        this.strength = (critterDetails.strength ? critterDetails.strength : 1) * difficultyScale.strength;
         this.volume = critterDetails.volume ? critterDetails.volume : 1;
         this.unseenSounds = critterDetails.unseenSounds ? critterDetails.unseenSounds : [];
         this.seenSounds = critterDetails.seenSounds ? critterDetails.seenSounds : [];

--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -83,6 +83,7 @@ class Entity {
         }
         this.actPeriod = actPeriod;
         if (movePeriod) {
+            movePeriod = Math.min(movePeriod, actPeriod);
             this.spriteSpeed = 1 / (movePeriod);
         } else {
             this.spriteSpeed = 1 / (this.actPeriod);

--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -42,6 +42,8 @@ class Game {
 
     muteSprite: Sprite;
 
+    difficulty: number;
+
     init() {
         // Initialize the Pixi application.
         this.pixiApp = new Application({
@@ -131,6 +133,10 @@ class Game {
         this.ticker.start();
     }
 
+    setDifficulty(difficulty:number) {
+        this.difficulty = difficulty;
+    }
+
     // Deal with resizing of the browser window
     handleResize() {
         // Overall canvas size
@@ -161,7 +167,7 @@ class Game {
             resetFunction();
         }
         this.currentLevel = level;
-        this.mapHandler.generateNewMap({level: level, fresh:fresh});
+        this.mapHandler.generateNewMap({level: level, fresh:fresh, difficulty: this.difficulty ? this.difficulty : 1});
         this.active = true;
         UI.getInstance().closeInventory();
         UI.getInstance().closeSpecialMessageModal();
@@ -255,6 +261,10 @@ class Game {
                 this.ticker.start();
             }
         } else {
+            if (UI.getInstance().messageOpen || UI.getInstance().inventoryOpen) {
+                // Ignore inputs when UI is open
+                return;
+            }
             if (this.player) {
                 this.player.handleInput(event, eventType, noBuffer);
             }

--- a/src/classes/MapHandler.ts
+++ b/src/classes/MapHandler.ts
@@ -14,6 +14,7 @@ import UI from "./UI"
 import themes from "../util/themes"
 import { randomElement } from "../util/randomness"
 import SoundHandler from "./SoundHandler"
+import { itemNumber, monsterCountFactor, roomCountFactor } from "../util/difficultySettings"
 
 interface MapHandlerParams {
     tileContainer: Container;
@@ -24,6 +25,7 @@ interface MapHandlerParams {
 interface NewMapParams {
     level: number;
     fresh?: boolean;
+    difficulty: number;
 }
 
 /**
@@ -95,73 +97,90 @@ class MapHandler {
     }
 
     // Generate a new map!
-    generateNewMap({level, fresh}:NewMapParams) {
+    generateNewMap({level, fresh, difficulty}:NewMapParams) {
         // Totally fresh game. Which means: ditch the existing Player
         if (fresh) {
             Game.getInstance().player = null;
         }
         this.clearOldMap()
 
+        const monsterFactor = monsterCountFactor(difficulty);
+        const roomFactor = roomCountFactor(difficulty);
+        const itemIterations = itemNumber(difficulty);
+
         let generatedMap:ReturnType<typeof mapGenerator>;
         if (level === 1) {
             Logger.getInstance().sendMessage("This furniture store is cursed. Do what you must to survive, and escape this vile place!", {tone:"good", important:true});
             generatedMap = mapGenerator({
-                monsterCount: 5,
-                targetRoomCount: 5,
-                noBigGuy: true
+                monsterCount: 5 * monsterFactor,
+                targetRoomCount: 5 * roomFactor,
+                noBigGuy: true,
+                itemIterations: itemIterations
             });
         } else if (level === 2) {
             Logger.getInstance().sendMessage("You've reached the second floor. Your spine tingles; you know you are not alone. Something is hunting you...", {tone:"good", important:true});
             generatedMap = mapGenerator({
-                monsterCount: 7,
-                targetRoomCount: 6,
+                monsterCount: 7 * monsterFactor,
+                targetRoomCount: 6 * roomFactor,
+                bonusGoodItems: difficulty < 2 ? ["bomb"] : [],
+                noBigGuy: difficulty < 2,
+                itemIterations: itemIterations
             });
         } else if (level === 3) {
             Logger.getInstance().sendMessage("You've reached the third floor. The cheerful looking walls of this place mock you, for you know what lies behind them.", {tone:"good", important:true});
             generatedMap = mapGenerator({
-                monsterCount: 8,
-                targetRoomCount: 8,
+                monsterCount: 8 * monsterFactor,
+                targetRoomCount: 8 * roomFactor,
                 monsterOptions: ["chair", "chair", "chair", "lamp"],
-                bonusGoodItems: ["bomb"]
+                bonusGoodItems: ["bomb"],
+                noBigGuy: difficulty < 1,
+                itemIterations: itemIterations
             });
         } else if (level === 4) {
             Logger.getInstance().sendMessage("You've reached the fourth floor. Office furniture is here. You hear the distant sound of wheels turning.", {tone:"good", important:true});
             generatedMap = mapGenerator({
-                monsterCount: 11,
+                monsterCount: 11 * monsterFactor,
+                targetRoomCount: 10 * roomFactor,
                 monsterOptions: ["chair", "chair", "rolly", "lamp", "lamp"],
-                bonusGoodItems: ["bomb","chainsaw"]
+                bonusGoodItems: ["bomb","chainsaw"],
+                itemIterations: itemIterations
             });
         } else if (level === 5) {
             Logger.getInstance().sendMessage("You've reached the fifth floor. The stench of brimstone and burnt meat fills the air.", {tone:"good", important:true});
             generatedMap = mapGenerator({
-                monsterCount: 13,
+                monsterCount: 13 * monsterFactor,
+                targetRoomCount: 10 * roomFactor,
                 monsterOptions: ["chair","rolly","lamp","kallax"],
-                bonusGoodItems: ["bomb","chainsaw"]
+                bonusGoodItems: ["bomb","chainsaw"],
+                itemIterations: itemIterations
             });
         } else if (level === 6) {
             Logger.getInstance().sendMessage("You've reached the sixth floor. For a moment, you saw a skittering creature at the edge of your vision, only for it to be gone a moment later.", {tone:"good", important:true});
             generatedMap = mapGenerator({
-                monsterCount: 15,
-                targetRoomCount: 12,
+                monsterCount: 15 * monsterFactor,
+                targetRoomCount: 12 * roomFactor,
                 monsterOptions: ["chair", "chair", "lamp","rolly", "kallax","healer"],
-                bonusGoodItems: ["bomb","chainsaw"]
+                bonusGoodItems: ["bomb","chainsaw"],
+                itemIterations: itemIterations
             });
         } else if (level === 7) {
             Logger.getInstance().sendMessage("You've reached the seventh floor. The sound of static fills the air.", {tone:"good", important:true});
             generatedMap = mapGenerator({
-                monsterCount: 15,
-                targetRoomCount: 12,
+                monsterCount: 15 * monsterFactor,
+                targetRoomCount: 12 * roomFactor,
                 monsterOptions: ["chair", "chair", "lamp","rolly", "kallax","tv","healer"],
-                bonusGoodItems: ["bomb","chainsaw"]
+                bonusGoodItems: ["bomb","chainsaw"],
+                itemIterations: itemIterations
             });
         } else {
             Logger.getInstance().sendMessage("You've reached the final floor. The air is just a little bit fresher here; you know you are almost free. But at what cost?", {tone:"good", important:true});
             generatedMap = mapGenerator({
-                monsterCount: 12,
-                targetRoomCount: 12,
+                monsterCount: 12 * monsterFactor,
+                targetRoomCount: 12 * roomFactor,
                 bonusGoodItems: ["bomb","chainsaw","bomb"],
                 monsterOptions: ["chair", "kallax", "rolly", "lamp", "tv", "healer"],
                 includeWinCondition: true,
+                itemIterations: itemIterations
             });
         }
         

--- a/src/classes/Player.ts
+++ b/src/classes/Player.ts
@@ -120,6 +120,10 @@ class Player extends Entity {
                     case "r":
                     case "E":
                     case "R":
+                        if (eventType === "repeat") {
+                            // Don't repeat reading
+                            break;
+                        }
                         if (this.currentTile && this.currentTile.interactive) {
                             this.currentTile.interactive.use();
                         } else {

--- a/src/classes/UI.ts
+++ b/src/classes/UI.ts
@@ -97,7 +97,6 @@ export default class UI {
                     let chosenDifficulty = 1
                     if (checkedRadio) {
                         chosenDifficulty = parseInt(checkedRadio.value);
-                        console.log(chosenDifficulty)
                     }
                     resolve(chosenDifficulty);
                 }

--- a/src/classes/UI.ts
+++ b/src/classes/UI.ts
@@ -29,6 +29,8 @@ export default class UI {
     specialMessageHeader: HTMLHeadingElement;
     specialMessageContent: HTMLDivElement;
     specialMessageButton: HTMLButtonElement;
+    specialMessageForm: HTMLFormElement;
+    specialMessageFieldset: HTMLFieldSetElement;
     inventoryOpen:boolean = false;
     messageOpen:boolean = false;
     actionButtonHolder: HTMLDivElement;
@@ -54,12 +56,20 @@ export default class UI {
         this.specialMessageHeader = document.getElementById("specialMessageHeader") as HTMLHeadingElement;
         this.specialMessageContent = document.getElementById("specialMessageContent") as HTMLDivElement;
         this.specialMessageButton = document.getElementById("specialMessageButton") as HTMLButtonElement;
+        this.specialMessageForm = document.getElementById("specialMessageForm") as HTMLFormElement;
+        this.specialMessageFieldset = document.getElementById("specialMessageFieldset") as HTMLFieldSetElement;
 
         // Setup needed for action buttons
         this.actionButtonHolder = document.getElementById("buttonHolder") as HTMLDivElement;
         this.actionButtons = new Map<string, HTMLButtonElement>();
 
-        this.specialMessageButton.addEventListener("click", () => {
+        this.specialMessageButton.addEventListener("click", (e) => {
+            e.preventDefault();
+            this.closeSpecialMessageModal();
+        });
+
+        this.specialMessageForm.addEventListener("submit", (e) => {
+            e.preventDefault();
             this.closeSpecialMessageModal();
         });
 
@@ -72,6 +82,27 @@ export default class UI {
         this.closeInventoryButton.addEventListener("click", () => {
             this.closeInventory();
         });
+    }
+
+    showDifficultySelection() : Promise<number> {
+        return new Promise((resolve) => {
+            this.specialMessageFieldset.classList.remove("hide");
+            this.showSpecialMessageModal({
+                headingText: "Difficulty Select",
+                body: ["Welcome to Furniture: Screws and Blood! Please choose a difficulty level to begin."],
+                button: "Click to begin!",
+                handler: () => {
+                    this.specialMessageFieldset.classList.add("hide");
+                    const checkedRadio = document.querySelector(`input[type="radio"]:checked`) as HTMLInputElement;
+                    let chosenDifficulty = 1
+                    if (checkedRadio) {
+                        chosenDifficulty = parseInt(checkedRadio.value);
+                        console.log(chosenDifficulty)
+                    }
+                    resolve(chosenDifficulty);
+                }
+            })
+        })
     }
 
     showSpecialMessageModal({headingText, body, button = "Close", handler}:SpecialMessageParams) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ import preloadAssets from "./util/preloadAssets"
 // Start up the game!
 async function init() {
     await preloadAssets();
+    const difficulty = await UI.getInstance().showDifficultySelection();
     const game = Game.getInstance();
+    game.setDifficulty(difficulty);
     game.newMap(1,true);
     UI.getInstance().showSpecialMessageModal({
         headingText: "Furniture: Screws and Blood",

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -85,6 +85,62 @@ li {
     margin: 10px 0;
 }
 
+.modal fieldset {
+    display: flex;
+    text-align: center;
+    border: none;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.modal fieldset.hide {
+    display: none;
+}
+
+.modal fieldset label {
+    border: 1.5px solid white;
+    padding: 5px;
+    margin: 10px;
+    border-radius: 5px;
+    position: relative;
+    transition: 0.3s border, 0.3s color;
+}
+
+fieldset input {
+    appearance: none;
+}
+
+fieldset input:focus-visible {
+    outline: none;
+}
+
+input:checked + label {
+    color: red;
+    border-color: red;
+}
+
+input:checked + label::before, input:checked + label::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    color: red;
+}
+
+input:checked + label::before {
+    content: ">";
+    left: calc(-5px - 1rem);
+}
+
+input:checked + label::after {
+    content: "<";
+    right: calc(-5px - 1rem);
+}
+
+input:focus-visible + label {
+    outline: 2px solid red;
+}
+
 .inventory {
     z-index: 10;
 }

--- a/src/util/difficultySettings.ts
+++ b/src/util/difficultySettings.ts
@@ -33,13 +33,13 @@ export const monsterStrengthScale = (difficulty:number):{strength:number, speed:
         return {
             strength: 0.75,
             speed: 0.8,
-            health: 0.75
+            health: 0.7
         }
     } else if (difficulty === 1) {
         return {
             strength: 0.9,
             speed: 0.9,
-            health: 0.9
+            health: 0.8
         }
     } else if (difficulty === 2) {
         return {

--- a/src/util/difficultySettings.ts
+++ b/src/util/difficultySettings.ts
@@ -1,0 +1,57 @@
+export const monsterCountFactor = (difficulty:number) => {
+    if (difficulty <= 0) {
+        return 0.75;
+    } else if (difficulty === 1) {
+        return 0.9;
+    } else if (difficulty === 2) {
+        return 1;
+    } else {
+        return 1.2;
+    }
+};
+
+export const roomCountFactor = (difficulty:number) => {
+    if (difficulty <= 2) {
+        return 1;
+    } else {
+        return 1.2;
+    }
+};
+
+export const itemNumber = (difficulty:number) => {
+    if (difficulty === 0) {
+        return 5;
+    } else if (difficulty === 1) {
+        return 4;
+    } else {
+        return 3;
+    }
+}
+
+export const monsterStrengthScale = (difficulty:number):{strength:number, speed:number, health:number} => {
+    if (difficulty === 0) {
+        return {
+            strength: 0.75,
+            speed: 0.8,
+            health: 0.75
+        }
+    } else if (difficulty === 1) {
+        return {
+            strength: 0.9,
+            speed: 0.9,
+            health: 0.9
+        }
+    } else if (difficulty === 2) {
+        return {
+            strength: 1,
+            speed: 1,
+            health: 1
+        }
+    } else {
+        return {
+            strength: 1.2,
+            speed: 1.1,
+            health: 1
+        }
+    }
+}

--- a/src/util/mapGenerator.ts
+++ b/src/util/mapGenerator.ts
@@ -3,7 +3,7 @@ import Pathfinder from "../classes/Pathfinder"
 import { critterTypes } from "./entityTypes"
 import themes from "./themes"
 
-interface MapGenParams {
+export interface MapGenParams {
     minRoomSize?: number;
     maxRoomSize?: number;
     targetRoomCount?: number;
@@ -13,6 +13,7 @@ interface MapGenParams {
     noBigGuy?: boolean;
     includeWinCondition?: boolean;
     bonusGoodItems?: string[];
+    itemIterations?: number;
 }
 
 interface TilePlan {
@@ -51,7 +52,7 @@ const veryGoodItems = ["hammer", "medkit", "hammer", "medkit"];
 /**
  * Cool function to generate the map
  */
-export default function mapGenerator({minRoomSize=5, maxRoomSize=10, targetRoomCount=10, multipleConnectionChance=0.5, monsterCount=10, monsterOptions=["chair"], noBigGuy=false, includeWinCondition=false, bonusGoodItems=[]}:MapGenParams = {}) {
+export default function mapGenerator({minRoomSize=5, maxRoomSize=10, targetRoomCount=10, multipleConnectionChance=0.5, monsterCount=10, monsterOptions=["chair"], noBigGuy=false, includeWinCondition=false, bonusGoodItems=[], itemIterations=3}:MapGenParams = {}) {
     const map = new Map<string, TilePlan>();
     const rooms:RoomData[] = [];
     const roomConnectionTracker:number[][] = [];
@@ -292,7 +293,7 @@ export default function mapGenerator({minRoomSize=5, maxRoomSize=10, targetRoomC
 
     // Add some items
     const items:ItemData[] = [];
-    for (let i=0; i<3; i++) {
+    for (let i=0; i<itemIterations; i++) {
         items.push({
             name: randomElement(["sword","hammer","hex key"]),
             key: randomElement(entitySpots),


### PR DESCRIPTION
Update to add in some difficulty settings. There are four.

Things they change are:
- Number of monsters spawned
- Number of rooms generated
- Number of items placed
- HP of enemies
- Speed of enemies
- Damage strength of enemies.

The prior difficulty is still present as "classic". But, the new "suggested" difficulty has:
- 1 or 2 fewer monsters per level
- 1 extra weapon, bandage, and medkit
- Monster strength,and speed to 90%. HP to a factor of 80%
- Sofa appears a level later

Easy mode further reduces these:
- 3/4 as many enemies
- 5/3 as many non-fancy items
- Monster strength 0.75, health of 0.7, and speed of 0.8
- Sofa appears 2 levels later

Nightmare, conversely, cranks a bunch of knobs up.
- 20% more enemies, avoiding enemies is far more important than picking fights
- 20% more rooms, to moderate the above a bit, since foes will be a bit more spread out.
- 20% more monster attack strength, 10% more monster attack speed (The player will take 32% more damage on average if they are careless)